### PR TITLE
Improve build system slightly

### DIFF
--- a/libdisk/Makefile
+++ b/libdisk/Makefile
@@ -14,9 +14,9 @@ LIBS += $(LIBS-y)
 
 all:
 ifneq ($(SHARED_LIB),n)
-	$(MAKE) -C stream streams.opic
-	$(MAKE) -C container containers.opic
-	$(MAKE) -C format formats.opic
+	$(MAKE) -C stream streams.a
+	$(MAKE) -C container containers.a
+	$(MAKE) -C format formats.a
 	$(MAKE) libdisk.so
 else
 	$(MAKE) -C stream streams.o
@@ -28,8 +28,8 @@ endif
 libdisk.a: $(OBJS) stream/streams.o container/containers.o format/formats.o
 	$(AR) rc $@ $^
 
-libdisk.so: $(PICOBJS) stream/streams.opic container/containers.opic \
-		format/formats.opic
+libdisk.so: $(PICOBJS) stream/streams.a container/containers.a \
+		format/formats.a
 	$(CC) -Wl,-h,$(@).$(MAJOR) -shared $(LIBS) -o $(@).$(MAJOR).$(MINOR) $^
 	ln -sf $(@).$(MAJOR).$(MINOR) $(@).$(MAJOR)
 	ln -sf $(@).$(MAJOR) $(@)

--- a/libdisk/container/Makefile
+++ b/libdisk/container/Makefile
@@ -10,8 +10,8 @@ all: containers.o containers.opic
 containers.o: $(OBJS)
 	$(LD) -r -o $@ $^
 
-containers.opic: $(PICOBJS)
-	$(LD) -r -o $@ $^
+containers.a: $(PICOBJS)
+	$(AR) rs $@ $^
 
 clean:
 	$(RM) *.a *.o *.opic *.so* *~ $(DEPS)

--- a/libdisk/format/Makefile
+++ b/libdisk/format/Makefile
@@ -10,8 +10,8 @@ all: formats.o formats.opic
 formats.o: $(OBJS)
 	$(LD) -r -o $@ $^
 
-formats.opic: $(PICOBJS)
-	$(LD) -r -o $@ $^
+formats.a: $(PICOBJS)
+	$(AR) rs $@ $^
 
 clean:
 	$(RM) *.a *.o *.opic *.so* *~ $(DEPS)

--- a/libdisk/stream/Makefile
+++ b/libdisk/stream/Makefile
@@ -19,5 +19,8 @@ streams.o: $(OBJS)
 streams.opic: $(PICOBJS)
 	$(LD) -r -o $@ $^
 
+streams.a: $(PICOBJS)
+	$(AR) rs $@ $^
+
 clean:
 	$(RM) *.a *.o *.opic *.so* *~ $(DEPS)


### PR DESCRIPTION
Some compilers (like Apple's GCC) will not accept .o files combined with ld. So it's better to use ar to combine them into static archives.
