### PR TITLE
Handle endian conversion internally

### DIFF
--- a/libdisk/include/libdisk/util.h
+++ b/libdisk/include/libdisk/util.h
@@ -14,7 +14,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <endian.h>
 
 #ifndef offsetof
 #define offsetof(a,b) __builtin_offsetof(a,b)
@@ -64,6 +63,11 @@ uint32_t crc32(const void *buf, size_t len);
 
 uint16_t crc16_ccitt(const void *buf, size_t len, uint16_t crc);
 uint16_t crc16_ccitt_bit(uint8_t b, uint16_t crc);
+
+uint16_t htobe16(uint16_t host_16bits);
+uint32_t htobe32(uint32_t host_32bits);
+uint16_t be16toh(uint16_t big_endian_16bits);
+uint32_t be32toh(uint32_t big_endian_32bits);
 
 #pragma GCC visibility pop
 

--- a/libdisk/util.c
+++ b/libdisk/util.c
@@ -158,6 +158,26 @@ uint16_t crc16_ccitt_bit(uint8_t b, uint16_t crc)
     return crc;
 }
 
+uint16_t htobe16(uint16_t host_16bits) {
+    uint16_t result;
+    ((uint8_t*)(&result))[0] = (host_16bits >> 8) & 0xff;
+	((uint8_t*)(&result))[1] = (host_16bits & 0xff);
+    return result;
+}
+uint32_t htobe32(uint32_t host_32bits) {
+    uint32_t result;
+    ((uint16_t*)(&result))[0] = (htobe16(host_32bits >> 16) & 0xffff);
+	((uint16_t*)(&result))[1] = htobe16(host_32bits & 0xffff);
+    return result;
+}
+uint16_t be16toh(uint16_t big_endian_16bits) {
+    return ((uint8_t*)(&big_endian_16bits))[1] | (((uint8_t*)(&big_endian_16bits))[0] << 8);
+}
+uint32_t be32toh(uint32_t big_endian_32bits) {
+    return (be16toh(((uint16_t*)(&big_endian_32bits))[0]) << 16) | be16toh(((uint16_t*)(&big_endian_32bits))[1]);
+}
+
+
 /*
  * Local variables:
  * mode: C


### PR DESCRIPTION
htobe() etc. are nonstandard. This should work on all platforms — I tested it on Intel x86 as well as PowerPC.
