### PR TITLE
Remove unnecessary include

### DIFF
--- a/libdisk/stream/caps_disabled.c
+++ b/libdisk/stream/caps_disabled.c
@@ -13,7 +13,6 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <unistd.h>
-#include <dlfcn.h>
 
 #define w(f, a...) fprintf(stderr, "*** " f, ## a)
 


### PR DESCRIPTION
This breaks MinGW support, because dlopen() etc aren't present in Win32. At some point, a caps_windows.c should probably be added to interface with the Windows build of the CAPS library.
