### PR TITLE
Use more standard versions of rand() and localtime() which are present on Win32

### DIFF
--- a/libdisk/container/ipf.c
+++ b/libdisk/container/ipf.c
@@ -292,7 +292,7 @@ static bool_t __ipf_close(struct disk *d, uint32_t encoder)
     ipf_write_chunk(d, "CAPS", NULL, 0);
 
     t = time(NULL);
-    localtime_r(&t, &tm);
+    tm = *(localtime(&t));
     if (tm.tm_sec > 59)
         tm.tm_sec = 59;
 

--- a/libdisk/disk.c
+++ b/libdisk/disk.c
@@ -457,9 +457,8 @@ void tbuf_weak(struct track_buffer *tbuf, uint16_t speed, unsigned int bits)
     if (tbuf->weak != NULL) {
         tbuf->weak(tbuf, speed, bits);
     } else {
-        static unsigned int seed = 0;
         while (bits--)
-            tbuf->bit(tbuf, speed, MFM_all, rand_r(&seed) & 1);
+            tbuf->bit(tbuf, speed, MFM_all, rand() & 1);
     }
 }
 

--- a/libdisk/format/dungeon_master.c
+++ b/libdisk/format/dungeon_master.c
@@ -135,12 +135,11 @@ static void dungeon_master_weak_read_mfm(
         tbuf_bits(tbuf, SPEED_AVG, MFM_raw, 32, 0x44895545);
         if (sec == weak_sec) {
             uint16_t crc = crc16_ccitt(&dat[sec*512], 512, tbuf->crc16_ccitt);
-            static unsigned int seed = 0;
             tbuf_bytes(tbuf, SPEED_AVG, MFM_all, 32, &dat[sec*512]);
             /* Protection sector: randomise MSB of each byte in weak area. */
             for (i = 0; i < 512-64; i++)
                 tbuf_bits(tbuf, SPEED_AVG, MFM_all, 8,
-                          (rand_r(&seed) & 1) ? 0x68 : 0xe8);
+                          (rand() & 1) ? 0x68 : 0xe8);
             tbuf_bytes(tbuf, SPEED_AVG, MFM_all, 32, &dat[(sec+1)*512-32]);
             /* CRC is generated pre-randomisation. Restore it now. */
             tbuf->crc16_ccitt = crc;


### PR DESCRIPTION
Should we be setting the random seed to 0?
