### PR TITLE
Fix to siemens_isdx_hd format handler

### DIFF
--- a/libdisk/format/ibm_pc.c
+++ b/libdisk/format/ibm_pc.c
@@ -248,7 +248,7 @@ struct track_handler ibm_pc_ed_handler = {
 struct track_handler siemens_isdx_hd_handler = {
     .density = TRKDEN_mfm_high,
     .bytes_per_sector = 256,
-    .nr_sectors = 31,
+    .nr_sectors = 32,
     .write_mfm = ibm_pc_write_mfm,
     .read_mfm = ibm_pc_read_mfm
 };


### PR DESCRIPTION
It would be nice to have some way of determining how many sectors per track are present on a disk from the sector numbers.

Also, some MFM formats have sectors 0 to (n/2)-1 on side A and sectors n/2 to n on side B...
