### PR TITLE
Zero the EADF track header when it's first created.

### DIFF
--- a/libdisk/container/eadf.c
+++ b/libdisk/container/eadf.c
@@ -96,6 +96,7 @@ static void eadf_close(struct disk *d)
     write_exact(d->fd, &dhdr, sizeof(dhdr));
 
     memset(raw, 0, sizeof(raw));
+    memset(&thdr, 0, sizeof(thdr));
     thdr.type = htobe16(1);
     for (i = 0; i < di->nr_tracks; i++) {
         ti = &di->track[i];


### PR DESCRIPTION
Without this, libdisk will write junk into the reserved field, which confuses
rawadf (and presumably other EADF tools).
