### PR TITLE
Fix for building on win32 mingw-msys

### DIFF
--- a/adfread/adfread.c
+++ b/adfread/adfread.c
@@ -244,7 +244,11 @@ static void handle_dir(int fd, char *prefix, struct ffs_dir *dir)
     struct ffs_fileheader *file;
 
     if (!is_readonly)
+#ifndef __WIN32__
         (void)mkdir(prefix, 0777);
+#else
+        (void)mkdir(prefix);
+#endif
 
     strcat(prefix, "/");
     printf(" %-61s %s\n", prefix, format_datestamp(&dir->datestamp));


### PR DESCRIPTION
Fixes compiling on win32 when using mingw-msys to build.
