### PR TITLE
Potential fix for SCP on Mac OS X

### DIFF
--- a/scp/scp.c
+++ b/scp/scp.c
@@ -17,6 +17,10 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
+#if defined(__APPLE__)
+#define B3000000 3000000
+#endif
+
 #include "scp.h"
 
 #include "../libdisk/util.c"


### PR DESCRIPTION
Mac OS X doesn't have B3000000 defined. I have no idea whether this would work as I don't have a SuperCardPro yet.
