### PR TITLE
Initialize cur_offst variable

### DIFF
--- a/libdisk/stream/discferret_dfe2.c
+++ b/libdisk/stream/discferret_dfe2.c
@@ -143,7 +143,7 @@ static int dfe2_select_track(struct stream *s, unsigned int tracknr)
     uint16_t head = 0;
     uint16_t sector = 0;
     uint32_t data_length = 0;
-    off_t cur_offst;
+    off_t cur_offst = 0;
     
     if (dfss->dat && (dfss->track == tracknr))
         return 0;


### PR DESCRIPTION
This fixes compile with the latest Clang on Mac OS X. Not sure how it was missed.
