### PR TITLE
Fix uninitialized variable error in ibm.c

### DIFF
--- a/libdisk/format/ibm.c
+++ b/libdisk/format/ibm.c
@@ -182,7 +182,7 @@ fail:
 
 int ibm_scan_dam(struct stream *s)
 {
-    uint8_t mark;
+    uint8_t mark = 0;
     int idx_off = ibm_scan_mark(s, 1000, &mark);
     return (mark == IBM_MARK_DAM) ? idx_off : -1;
 }


### PR DESCRIPTION
This fixes an uninitialized variable error in the IBM format
parser reported by gcc 10.0.1 from Fedora 32. Initializing
the mark variable to 0 should be safe.