### PR TITLE
Two commits that allowed this to build on FreeBSD 11.4R

### DIFF
--- a/libdisk/container/imd.c
+++ b/libdisk/container/imd.c
@@ -235,11 +235,13 @@ static void imd_close(struct disk *d)
         if ((thdr.mode == 0xff) || !ti->nr_sectors)
             continue;
 
+#ifdef BOGUS /* nr_sectors is a uint8_t which has a range of 0..255 */
         if ((uint32_t)ti->nr_sectors >= 256) {
             warnx("T%u.%u: Unexpected number of IBM-MFM sectors (%u)",
                   cyl(trk), hd(trk), ti->nr_sectors);
             continue;
         }
+#endif
 
         retrieve_ibm_mfm_track(
             d, trk, &secs, &cyls, &heads, &nos, &marks, &crcs, &dat);

--- a/libdisk/container/jv3.c
+++ b/libdisk/container/jv3.c
@@ -455,8 +455,10 @@ static void jv3_close(struct disk *d)
         if (!ti->nr_sectors)
             continue;
 
+#ifdef BOGUS /* nr_sectors is a uint8_t which has a range of 0..255 */
         if ((uint32_t)ti->nr_sectors >= 256) 
             continue;
+#endif
 
         /* Simple reject_track tests are now done 
          * We can not reject mismatches here - crosstalk can happen */

--- a/libdisk/include/libdisk/util.h
+++ b/libdisk/include/libdisk/util.h
@@ -20,7 +20,11 @@
 #ifndef _BSD_SOURCE
 #define _BSD_SOURCE
 #endif
+#ifdef __FreeBSD__
+#include <sys/endian.h>
+#else
 #include <endian.h>
+#endif
 #endif
 
 #if !defined(__MINGW32__)


### PR DESCRIPTION
Here's a couple of minor tweaks that allow this to compile on FreeBSD. I've not extensively tested it yet, but the couple of samples I tried seem to just work after this.

First, older FreeBSD doesn't have endian.h, just sys/endian.h, so use that. Since FreeSBD 11.4R is still supported, this seems prudent.

Second, there's two places where nr_sectors is tested for >=256. Since it's a byte value, this is impossible and can never happen. I've ifdef'd them out, but would be happy to remove the code entirely too.
