### PR TITLE
build: use environment compilers and flags if defined

### DIFF
--- a/Rules.mk
+++ b/Rules.mk
@@ -29,13 +29,14 @@ INSTALL_DIR  = $(INSTALL) -d -m0755 -p
 INSTALL_DATA = $(INSTALL) -m0644 -p
 INSTALL_PROG = $(INSTALL) -m0755 -p
 
-AR := ar
-CC := gcc
-LD := ld
-OBJCOPY := objcopy
+AR ?= ar
+CC ?= gcc
+LD ?= ld
+OBJCOPY ?= objcopy
 RM := rm -f
 
-CFLAGS = -O2
+LDFLAGS ?=
+CFLAGS ?= -O2
 #CFLAGS = -O0 -g
 CFLAGS += -fno-strict-aliasing -std=gnu99 -Wall
 ifneq ($(PLATFORM),win32)

--- a/libdisk/Makefile
+++ b/libdisk/Makefile
@@ -15,21 +15,21 @@ ifeq ($(PLATFORM),osx)
 SOLIB   := $(SOLIB_PFX).dylib
 SONAME  := $(SOLIB_PFX).$(MAJOR_VERSION).dylib
 SOVERS  := $(SOLIB_PFX).$(MAJOR_VERSION).$(MINOR_VERSION).dylib
-LDFLAGS ?= -dynamiclib -install_name $(SONAME)
+LDFLAGS += -dynamiclib -install_name $(SONAME)
 endif
 
 ifeq ($(PLATFORM),linux)
 SOLIB   := $(SOLIB_PFX).so
 SONAME  := $(SOLIB_PFX).so.$(MAJOR_VERSION)
 SOVERS  := $(SOLIB_PFX).so.$(MAJOR_VERSION).$(MINOR_VERSION)
-LDFLAGS ?= -Wl,-h,$(SONAME) -shared
+LDFLAGS += -Wl,-h,$(SONAME) -shared
 endif
 
 ifeq ($(PLATFORM),win32)
 SOLIB   := $(SOLIB_PFX).dll
 SONAME  := $(SOLIB_PFX).$(MAJOR_VERSION).dll
 SOVERS  := $(SOLIB_PFX).$(MAJOR_VERSION).$(MINOR_VERSION).dll
-LDFLAGS ?= -Wl,-h,$(SONAME) -shared
+LDFLAGS += -Wl,-h,$(SONAME) -shared
 endif
 
 LIBS :=


### PR DESCRIPTION
- do not clobber compilers and CFLAGS if present in the environment
- ensure LDFLAGS always include the required flags for libdisk