### PR TITLE
Fix "dyld[7518]: Library not loaded: libdisk.0.dylib" error on macOS

### DIFF
--- a/libdisk/Makefile
+++ b/libdisk/Makefile
@@ -15,7 +15,7 @@ ifeq ($(PLATFORM),osx)
 SOLIB   := $(SOLIB_PFX).dylib
 SONAME  := $(SOLIB_PFX).$(MAJOR_VERSION).dylib
 SOVERS  := $(SOLIB_PFX).$(MAJOR_VERSION).$(MINOR_VERSION).dylib
-LDFLAGS += -dynamiclib -install_name $(SONAME)
+LDFLAGS += -dynamiclib -install_name "$(LIBDIR)/$(SONAME)"
 endif
 
 ifeq ($(PLATFORM),linux)


### PR DESCRIPTION
macOS seems unable to just find the library inside /usr/local/lib without specifying the full path.

Full error:

massimo@Lucifer ~ % disk-analyse
dyld[11283]: Library not loaded: libdisk.0.dylib
  Referenced from: <382EEDA0-B36E-3421-99F2-ACD65585B05E> /usr/local/bin/disk-analyse
  Reason: tried: 'libdisk.0.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OSlibdisk.0.dylib' (no such file), 'libdisk.0.dylib' (no such file), '/Users/massimo/libdisk.0.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/Users/massimo/libdisk.0.dylib' (no such file), '/Users/massimo/libdisk.0.dylib' (no such file)
zsh: abort      disk-analyse