### PR TITLE
Make diskread able to work on very old Amigas

### DIFF
--- a/amiga/native/diskread.c
+++ b/amiga/native/diskread.c
@@ -139,6 +139,7 @@ extern void __asm grab_track(
     register __d0 unsigned int count);
 
 #define BYTES_PER_TRACK (128*1024)
+#define TRACK_BUFFER_SIZE BYTES_PER_TRACK/2*3
 
 int main(int argc, char **argv)
 {
@@ -164,8 +165,8 @@ int main(int argc, char **argv)
         exit(1);
     }
 
-    if ((dat = malloc(BYTES_PER_TRACK)) == NULL) {
-        fprintf(stderr, "Could not alloc %u bytes\n", BYTES_PER_TRACK);
+    if ((dat = malloc(TRACK_BUFFER_SIZE)) == NULL) {
+        fprintf(stderr, "Could not alloc %u bytes\n", TRACK_BUFFER_SIZE);
         fclose(fp);
         release_drive();
         exit(1);

--- a/amiga/native/trackread.a
+++ b/amiga/native/trackread.a
@@ -5,32 +5,46 @@
 
 ; void grab_track(register __a0 char *dat, register __d0 int count);
 _grab_track:
-   MOVEM.L     D0-D4/A0-A3,-(SP)
+   MOVEM.L     D0-D4/A0-A4,-(SP)
    LEA.L       $DFF01A,A1  ; A1 = DSKBYTR
    LEA.L       $BFD400,A2  ; A2 = CIAA.CIATALO
    LEA.L       $BFDD00,A3  ; A3 = CIAA.CIAICR
+   MOVE.L      D0,D2       ; save the count for later
+   MOVE.L      A0,A4
+   ADDA.L      D0,A4       ; A4 is scratch memory after the main buffer
 
 byte_detect:
    MOVE.W      (A1),D1     ; D1 = DSKBYT
    BPL.B       byte_detect
 
+   MOVE.B      (A2),(A0)+  ; save THIS_CIATALO
+   MOVE.B      D1,(A0)+    ; set DSKBYT
+   MOVE.B      (A3),(A4)+  ; set DSKIDX
+   SUBQ.L      #2,D0
+   BNE.B       byte_detect
+
+
+   MOVE.L      A0,A4       ; Reset A0, D0 and A1 to their starting values
+   MOVE.L      D2,D0
+   SUBA.L      D0,A0
+
+fix_timing_byte:
    MOVE.B      D3,D2       ; D2 = PREV_CIATALO
-   MOVE.B      (A2),D3     ; D3 = THIS_CIATALO
+   MOVE.B      (A0),D3     ; D3 = THIS_CIATALO
    SUB.B       D3,D2       ; D2 = PREV_CIATALO - THIS_CIATALO
 
-   MOVE.B      (A3),D4
+   MOVE.B      (A4)+,D4
    LSL.B       #3,D4
    AND.B       #$80,D4
    OR.B        D4,D2       ; D2 |= DSKIDX << 7
 
-   LSL.W       #8,D2
-   MOVE.B      D1,D2       ; D2 <<= 8; D2 |= (UBYTE)DSKBYT
-   MOVE.W      D2,(A0)+
+   MOVE.B      D2,(A0)+
+   ADDA.L      #1,A0
 
    SUBQ.L      #2,D0
-   BNE.B       byte_detect
+   BNE.B       fix_timing_byte
 
-   MOVEM.L     (SP)+,D0-D4/A0-A3
+   MOVEM.L     (SP)+,D0-D4/A0-A4
    RTS
 
    END


### PR DESCRIPTION
This tightens up the assembly loop that reads from the amiga floppy (at the expense of buffer size), and also smooths the byte latency when reading a diskread file.