### PR TITLE
Handle MinGW32 on 64bit host

### DIFF
--- a/Rules.mk
+++ b/Rules.mk
@@ -4,6 +4,9 @@ all:
 
 ARCH ?= $(shell uname -m | sed -e s/i.86/x86_32/ \
           -e s/i86pc/x86_32/ -e s/amd64/x86_64/)
+ifeq ($(MSYSTEM),MINGW32)
+ARCH := x86_32
+endif
 
 ifeq ($(shell uname -s),Darwin)
 PLATFORM = osx


### PR DESCRIPTION
This change sets the correct architecture for MinGW32 if running on a 64bit host system